### PR TITLE
EXT-6451-Change content in Note Section for Toolbox Configuration UG

### DIFF
--- a/WindowsForms/Visual-Studio-Integration/Toolbox-Configuration.md
+++ b/WindowsForms/Visual-Studio-Integration/Toolbox-Configuration.md
@@ -53,5 +53,6 @@ Use the following steps to add the Syncfusion WinForms controls through the Sync
    ![Toolbox Installer](Toolbox-Configuration_images/Toolbox-Configuration_img3.png)
    
    
-   N> * You must reset the toolbox, when the installed controls are not reflected properly in the Toolbox. * This tool configures only the controls that are located under {Installed Location}\Assemblies\{Framework version}.
+   N> * If your installed controls are not reflected properly in the Visual Studio Toolbox, you'll have to reset the Toolbox. 
+   * This tool configures only the controls that are located under {Installed Location}\Assemblies\{Framework version}.
    


### PR DESCRIPTION
Changed content in note section as per customer requested

**Existing content:** You must reset the toolbox, when the installed controls are not reflected properly in the Toolbox.

**Replaced content:** If your installed controls are not reflected properly in the Visual Studio Toolbox, you'll have to reset the Toolbox. 