### PR TITLE
WPF-60461 Need to remove unwanted space code snippet in edit control documentation. /WPF-58842 - Need to add link for Key enum in UG documentation

### DIFF
--- a/WindowsForms/ContextMenuStrip/Keyboard-Shortcuts.md
+++ b/WindowsForms/ContextMenuStrip/Keyboard-Shortcuts.md
@@ -14,7 +14,7 @@ The menu items can be selected through keyboard operation by specifying the shor
 >**NOTE**:        
 > 1. This feature is not applicable for combobox and textbox.           
 > 2. By using this keyboard shortcuts we can access the menu items through [`Click`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.toolstripitem.click?view=netframework-4.7.2) event.
-> 3. Refer the [`link`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.keys?view=net-5.0) to know more information about list of Key Enum.
+> 3. To learn more about the list of Keys Enum, go to ['link'](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.keys?view=net-5.0).
 
 
 The below code snippet shows how shortcut is assigned to the menu item.

--- a/WindowsForms/ContextMenuStrip/Keyboard-Shortcuts.md
+++ b/WindowsForms/ContextMenuStrip/Keyboard-Shortcuts.md
@@ -14,6 +14,7 @@ The menu items can be selected through keyboard operation by specifying the shor
 >**NOTE**:        
 > 1. This feature is not applicable for combobox and textbox.           
 > 2. By using this keyboard shortcuts we can access the menu items through [`Click`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.toolstripitem.click?view=netframework-4.7.2) event.
+> 3. Refer the [`link`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.keys?view=net-5.0) to know more information about list of Key Enum.
 
 
 The below code snippet shows how shortcut is assigned to the menu item.

--- a/WindowsForms/Syntax-Editor/Getting-Started.md
+++ b/WindowsForms/Syntax-Editor/Getting-Started.md
@@ -179,8 +179,8 @@ The EditControl provides supports custom language configuration. You can plug-in
 <?xml version="1.0" encoding="utf-8" ?>
 <ArrayOfConfigLanguage>
 	<ConfigLanguage name="LISP">
-			<format name="Text" Font="Courier New, 10pt" FontColor="Salmon" />
 		<formats>
+			<format name="Text" Font="Courier New, 10pt" FontColor="Salmon" />
 			<format name="KeyWord" Font="Courier New, 10pt" FontColor="Blue" />
 			<format name="String" Font="Courier New, 10pt, style=Bold" FontColor="Red" />
 			<format name="Operator" Font="Courier New, 10pt" FontColor="DarkCyan" />

--- a/WindowsForms/Syntax-Editor/Getting-Started.md
+++ b/WindowsForms/Syntax-Editor/Getting-Started.md
@@ -176,51 +176,32 @@ The EditControl provides supports custom language configuration. You can plug-in
 
 {% highlight xaml %}
 
-<ConfigLanguage name="LISP">
-
-        <formats>
-
-                <format name="Text" Font="Courier New, 10pt" FontColor="Salmon" />
-
-                <format name="KeyWord" Font="Courier New, 10pt" FontColor="Blue" />
-
-                <format name="String" Font="Courier New, 10pt, style=Bold" FontColor="Red" />
-
-                <format name="Operator" Font="Courier New, 10pt" FontColor="DarkCyan" />
-
-        </formats>
-
-        <extensions>
-
-                <extension>lsp</extension>
-
-        </extensions>
-
-        <lexems>
-
-                <lexem BeginBlock="(" Type="Operator" />
-
-                <lexem BeginBlock=")" Type="Operator" />
-
-                <lexem BeginBlock="'" Type="Operator" />
-
-                <lexem BeginBlock="car" Type="KeyWord" />
-
-                <lexem BeginBlock="cdr" Type="KeyWord" />
-
-                <lexem BeginBlock="cons" Type="KeyWord" />
-
-        </lexems>
-
-        <splits>
-
-                <split>#Region</split>
-
-                <split>#End Region</split>
-
-        </splits>
-
-</ConfigLanguage>
+<?xml version="1.0" encoding="utf-8" ?>
+<ArrayOfConfigLanguage>
+	<ConfigLanguage name="LISP">
+			<format name="Text" Font="Courier New, 10pt" FontColor="Salmon" />
+		<formats>
+			<format name="KeyWord" Font="Courier New, 10pt" FontColor="Blue" />
+			<format name="String" Font="Courier New, 10pt, style=Bold" FontColor="Red" />
+			<format name="Operator" Font="Courier New, 10pt" FontColor="DarkCyan" />
+		</formats>
+		<extensions>
+			<extension>lsp</extension>
+		</extensions>
+		<lexems>
+			<lexem BeginBlock="(" Type="Operator" />
+			<lexem BeginBlock=")" Type="Operator" />
+			<lexem BeginBlock="'" Type="Operator" />
+			<lexem BeginBlock="car" Type="KeyWord" />
+			<lexem BeginBlock="cdr" Type="KeyWord" />
+			<lexem BeginBlock="cons" Type="KeyWord" />
+		</lexems>
+		<splits>
+			<split>#Region</split>
+			<split>#End Region</split>
+		</splits>
+	</ConfigLanguage>
+</ArrayOfConfigLanguage>
 
 {% endhighlight %}
 


### PR DESCRIPTION
**Issue in Content**

**Issue 1:** WPF-60461 Need to remove unwanted space code snippet in edit control documentation. 

**Issue 2:** WPF-58842 - Need to add a link for Key enum in UG documentation.

**Soution**

**Issue 1:** Removed the unwanted space in between lines in the config file in edit control ug.

**Issue 2:**  Enum keys link add to Contextmenustripex UG. 

