### PR TITLE
ES-949559 Remove Net 6.0 and Net 7.0 references from WinForms UG documentation

### DIFF
--- a/WindowsForms/System-Requirements.md
+++ b/WindowsForms/System-Requirements.md
@@ -35,5 +35,5 @@ This section describes the system requirements to use Syncfusion<sup>®</sup> Wi
 * Microsoft Visual Studio 2015/2017/2019/2022
 * .NET Framework 4.6.2
 * Lower Syncfusion<sup>®</sup> .NET frameworks can be used in applications because they are compatible with .NET 4.7, .NET 4.7.1, .NET 4.7.2, and .NET 4.8. For example, in the application, the Syncfusion<sup>®</sup> 4.6.2 .NET framework assembly can be referred to as 4.7 or higher target versions.
-* .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0.
+* .NET 8.0, .NET 9.0.
 

--- a/WindowsForms/Visual-Studio-Integration/Toolbox-Configuration.md
+++ b/WindowsForms/Visual-Studio-Integration/Toolbox-Configuration.md
@@ -56,8 +56,8 @@ Use the following steps to add the Syncfusion® WinForms controls through the Sy
 
 From 2021 Volume 3, Syncfusion® started providing toolbox support for .NET Framework in Visual Studio 2022 Toolbox. After installing the Syncfusion® Windows Forms installer, Syncfusion® controls will be automatically configured in the Visual Studio 2022 toolbox for Windows Forms .NET Framework projects.
 
-## Configuring toolbox for Windows Forms .NET 6.0\8.0 projects from NuGet packages
+## Configuring toolbox for Windows Forms .NET 8.0\9.0 projects from NuGet packages
 
-From 2021 Volume 3, Syncfusion® started providing toolbox support for Windows Forms .NET 6.0\8.0 projects. Please install the respective Syncfusion® WinForms NuGet packages in .NET 6.0\8.0 project to get the Syncfusion® WinForms controls in the .NET 6.0\8.0 Toolbox. After installing the NuGet packages, our WinForms controls will be populated in the Visual Studio toolbox for .NET 6.0\8.0 WinForms project.
+From 2021 Volume 3, Syncfusion® started providing toolbox support for Windows Forms .NET 8.0\9.0 projects. Please install the respective Syncfusion® WinForms NuGet packages in .NET 8.0\9.0 project to get the Syncfusion® WinForms controls in the .NET 8.0\9.0 Toolbox. After installing the NuGet packages, our WinForms controls will be populated in the Visual Studio toolbox for .NET 8.0\9.0 WinForms project.
 
 Refer [this](https://help.syncfusion.com/windowsforms/add-syncfusion-controls) documentation link to find Syncfusion® WinForms nuget packages for the appropriate controls.

--- a/WindowsForms/dotnet-framework-compatibility.md
+++ b/WindowsForms/dotnet-framework-compatibility.md
@@ -31,19 +31,6 @@ Syncfusion<sup>®</sup> Version </th>
 
 <tr>
 <td>
-Earlier Version</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-No</td><td>
-No</td><td>
-No</td><td>
-No</td><td>
-No</td><td>
-No</td></tr>
-
-<tr>
-<td>
 From 28.1 (2024 Vol4)</td><td>
 No</td><td>
 No</td><td>
@@ -54,6 +41,7 @@ Yes</td><td>
 Yes</td><td>
 Yes</td><td>
 Yes</td></tr>
+
 <tr>
 <td>
 From 27.2 (2024 Vol3 SP)</td><td>
@@ -171,21 +159,17 @@ No</td><td>
 No</td><td>
 No</td></tr>
 
-
-
-
-
-
-
-
-
-
-
-
-
->
-
-
-
+<tr>
+<td>
+Earlier Version</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+No</td><td>
+No</td><td>
+No</td><td>
+No</td><td>
+No</td><td>
+No</td></tr>
 
 </table>

--- a/WindowsForms/dotnet-framework-compatibility.md
+++ b/WindowsForms/dotnet-framework-compatibility.md
@@ -44,20 +44,84 @@ No</td></tr>
 
 <tr>
 <td>
-From 11.2 (2013 Vol2)</td><td>
+From 28.1 (2024 Vol4)</td><td>
+No</td><td>
+No</td><td>
+No</td><td>
+No</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td></tr>
+<tr>
+<td>
+From 27.2 (2024 Vol3 SP)</td><td>
+No</td><td>
+No</td><td>
+Yes</td><td>
+No</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td></tr>
+
+<tr>
+<td>
+From 23.2 (2023 Vol3 SP)</td><td>
+No</td><td>
+No</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+No</td></tr>
+
+<tr>
+<td>
+From 21.1 (2023 Vol1)</td><td>
+No</td><td>
+No</td><td>
+Yes</td><td>
 Yes</td><td>
 Yes</td><td>
 Yes</td><td>
 Yes</td><td>
 No</td><td>
+No</td></tr>
+
+<tr>
+<td>
+From 20.4 (2022 Vol4)</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
 No</td><td>
+No</td></tr>
+
+<tr>
+<td>
+From 19.4 (2021 Vol4)</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
+Yes</td><td>
 No</td><td>
 No</td><td>
 No</td></tr>
 
 <tr>
 <td>
-From 13.3 (2015 Vol3)</td><td>
+From 18.4 (2020 Vol4)</td><td>
 Yes</td><td>
 Yes</td><td>
 Yes</td><td>
@@ -83,7 +147,7 @@ No</td></tr>
 
 <tr>
 <td>
-From 18.4 (2020 Vol4)</td><td>
+From 13.3 (2015 Vol3)</td><td>
 Yes</td><td>
 Yes</td><td>
 Yes</td><td>
@@ -96,80 +160,32 @@ No</td></tr>
 
 <tr>
 <td>
-From 19.4 (2021 Vol4)</td><td>
+From 11.2 (2013 Vol2)</td><td>
 Yes</td><td>
 Yes</td><td>
 Yes</td><td>
 Yes</td><td>
-Yes</td><td>
-Yes</td><td>
+No</td><td>
+No</td><td>
 No</td><td>
 No</td><td>
 No</td></tr>
 
-<tr>
-<td>
-From 20.4 (2022 Vol4)</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-No</td><td>
-No</td></tr>
 
-<tr>
-<td>
-From 21.1 (2023 Vol1)</td><td>
-No</td><td>
-No</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-No</td><td>
-No</td></tr>
 
-<tr>
-<td>
-From 23.2 (2023 Vol3 SP)</td><td>
-No</td><td>
-No</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-No</td></tr>
 
-<tr>
-<td>
-From 27.2 (2024 Vol3 SP)</td><td>
-No</td><td>
-No</td><td>
-Yes</td><td>
-No</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td></tr>
 
-<tr>
-<td>
-From 28.1 (2024 Vol4)</td><td>
-No</td><td>
-No</td><td>
-No</td><td>
-No</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td><td>
-Yes</td></tr>
+
+
+
+
+
+
+
+
+>
+
+
+
 
 </table>


### PR DESCRIPTION
## Description ##
[ES-949559 Remove Net 6.0 and Net 7.0 references from WinForms UG documentation](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/949559)
I have Removed the unwanted Net 6.0 and Net 7.0 references from WinForms UG documentation and rearranged the table content in dotnet-framework-compatibility.md file.