### PR TITLE
WF-949463 Add more information for TabControl Selection

### DIFF
--- a/WindowsForms/TabControl/FAQ/How-to-programmatically-select-a-Tab.md
+++ b/WindowsForms/TabControl/FAQ/How-to-programmatically-select-a-Tab.md
@@ -9,39 +9,99 @@ documentation: ug
 
 # How to programmatically select a tab?
 
-To programmatically select a specific tab in the TabControlAdv, you can use the SelectedIndex property or the SelectedTab property.
+To programmatically select a specific tab in the `TabControlAdv`, you can use the `SelectedIndex` property or the `SelectedTab` property.
 
 > **Note:**  
-> `tabControlAdv1` in the below examples refers to an instance of the [`Syncfusion.Windows.Forms.Tools.TabControlAdv`](https://help.syncfusion.com/cr/windowsforms/Syncfusion.Windows.Forms.Tools.TabControlAdv.html) control. Ensure the control is defined in the designer or instantiated in code, and its `Name` property is set to `tabControlAdv1`.
+> `tabControlAdv1` in the below examples refers to an instance of the [`Syncfusion.Windows.Forms.Tools.TabControlAdv`](https://help.syncfusion.com/cr/windowsforms/Syncfusion.Windows.Forms.Tools.TabControlAdv.html) control. Make sure this control and its tab pages are properly initialized either via designer or code.
 
 {% tabs %}
 
-{% highlight C# %}
+{% highlight csharp %}
 
-// Select Second Tab using SelectedTab
-this.tabControlAdv1.SelectedTab = this.tabPageAdv2;
+using System;
+using System.Windows.Forms;
+using Syncfusion.Windows.Forms.Tools;
 
-// OR
+namespace TabControlAdvExample
+{
+    public class MainForm : Form
+    {
+        private TabControlAdv tabControlAdv1;
+        private TabPageAdv tabPageAdv1;
+        private TabPageAdv tabPageAdv2;
 
-// Select Second Tab using SelectedIndex
-this.tabControlAdv1.SelectedIndex = 1;
+        public MainForm()
+        {
+            tabControlAdv1 = new TabControlAdv();
+            tabPageAdv1 = new TabPageAdv() { Text = "Tab 1" };
+            tabPageAdv2 = new TabPageAdv() { Text = "Tab 2" };
+
+            tabControlAdv1.TabPages.Add(tabPageAdv1);
+            tabControlAdv1.TabPages.Add(tabPageAdv2);
+            tabControlAdv1.Dock = DockStyle.Fill;
+
+            this.Controls.Add(tabControlAdv1);
+
+            // Programmatically select the second tab using SelectedIndex
+            tabControlAdv1.SelectedIndex = 1;
+
+            // OR use SelectedTab
+            tabControlAdv1.SelectedTab = tabPageAdv2;
+
+            this.Text = "TabControlAdv Example";
+            this.StartPosition = FormStartPosition.CenterScreen;
+            this.Size = new System.Drawing.Size(400, 300);
+        }
+
+        static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.Run(new MainForm());
+        }
+    }
+}
 {% endhighlight %}
 
-{% highlight VB %}
+{% highlight vbnet %}
 
-' Programmatically select a tab inside an event or method
-Private Sub TabControlAdv1_SelectedIndexChanged(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles TabControlAdv1.SelectedIndexChanged
+Imports System
+Imports System.Windows.Forms
+Imports Syncfusion.Windows.Forms.Tools
 
-    ' Select Second Tab using SelectedTab
-    Me.tabControlAdv1.SelectedTab = Me.tabPageAdv2
+Public Class MainForm
+    Inherits Form
 
-    ' OR
+    Private tabControlAdv1 As TabControlAdv
+    Private tabPageAdv1 As TabPageAdv
+    Private tabPageAdv2 As TabPageAdv
 
-    ' Select Second Tab using SelectedIndex
-    Me.tabControlAdv1.SelectedIndex = 1
+    Public Sub New()
+        tabControlAdv1 = New TabControlAdv()
+        tabPageAdv1 = New TabPageAdv() With {.Text = "Tab 1"}
+        tabPageAdv2 = New TabPageAdv() With {.Text = "Tab 2"}
 
-End Sub
+        tabControlAdv1.TabPages.Add(tabPageAdv1)
+        tabControlAdv1.TabPages.Add(tabPageAdv2)
+        tabControlAdv1.Dock = DockStyle.Fill
 
+        Me.Controls.Add(tabControlAdv1)
+
+        ' Programmatically select the second tab using SelectedIndex
+        tabControlAdv1.SelectedIndex = 1
+
+        ' OR use SelectedTab
+        tabControlAdv1.SelectedTab = tabPageAdv2
+
+        Me.Text = "TabControlAdv Example"
+        Me.StartPosition = FormStartPosition.CenterScreen
+        Me.Size = New Drawing.Size(400, 300)
+    End Sub
+
+    Public Shared Sub Main()
+        Application.EnableVisualStyles()
+        Application.Run(New MainForm())
+    End Sub
+End Class
 {% endhighlight %}
 
 {% endtabs %}

--- a/WindowsForms/TabControl/FAQ/How-to-programmatically-select-a-Tab.md
+++ b/WindowsForms/TabControl/FAQ/How-to-programmatically-select-a-Tab.md
@@ -9,44 +9,42 @@ documentation: ug
 
 # How to programmatically select a tab?
 
-The following code snippet illustrates the ways to select a Tab programmatically.
+To programmatically select a specific tab in the TabControlAdv, you can use the SelectedIndex property or the SelectedTab property.
+
+> **Note:**  
+> `tabControlAdv1` in the below examples refers to an instance of the [`Syncfusion.Windows.Forms.Tools.TabControlAdv`](https://help.syncfusion.com/cr/windowsforms/Syncfusion.Windows.Forms.Tools.TabControlAdv.html) control. Ensure the control is defined in the designer or instantiated in code, and its `Name` property is set to `tabControlAdv1`.
 
 {% tabs %}
 
 {% highlight C# %}
 
-
-//Select Second Tab.
-
+// Select Second Tab using SelectedTab
 this.tabControlAdv1.SelectedTab = this.tabPageAdv2;
 
-or
+// OR
 
-//Select Second Tab.
-
-this.tabControlAdv1.SelectedIndex= 1;
-
+// Select Second Tab using SelectedIndex
+this.tabControlAdv1.SelectedIndex = 1;
 {% endhighlight %}
 
 {% highlight VB %}
 
-
-
+' Programmatically select a tab inside an event or method
 Private Sub TabControlAdv1_SelectedIndexChanged(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles TabControlAdv1.SelectedIndexChanged
 
-'Select Second Tab.
+    ' Select Second Tab using SelectedTab
+    Me.tabControlAdv1.SelectedTab = Me.tabPageAdv2
 
-Me.tabControlAdv1.SelectedTab = Me.tabPageAdv2
+    ' OR
 
-or
-
-'Select Second Tab.
-
-Me.tabControlAdv1.SelectedIndex = 1
+    ' Select Second Tab using SelectedIndex
+    Me.tabControlAdv1.SelectedIndex = 1
 
 End Sub
 
 {% endhighlight %}
 
 {% endtabs %}
+
+
 

--- a/WindowsForms/TabControl/FAQ/How-to-programmatically-select-a-Tab.md
+++ b/WindowsForms/TabControl/FAQ/How-to-programmatically-select-a-Tab.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: How-to-programmatically-select-a-Tab | WindowsForms | Syncfusion®
-description: how to programmatically select a tab
+description: Clarified TabControlAdv usage and added complete C#/VB examples to show how to programmatically select a tab in WinForms.
 platform: windowsforms
 control: TabsPackage
 documentation: ug

--- a/WindowsForms/TabControl/FAQ/How-to-programmatically-select-a-Tab.md
+++ b/WindowsForms/TabControl/FAQ/How-to-programmatically-select-a-Tab.md
@@ -11,9 +11,6 @@ documentation: ug
 
 To programmatically select a specific tab in the `TabControlAdv`, you can use the `SelectedIndex` property or the `SelectedTab` property.
 
-> **Note:**  
-> `tabControlAdv1` in the below examples refers to an instance of the [`Syncfusion.Windows.Forms.Tools.TabControlAdv`](https://help.syncfusion.com/cr/windowsforms/Syncfusion.Windows.Forms.Tools.TabControlAdv.html) control. Make sure this control and its tab pages are properly initialized either via designer or code.
-
 {% tabs %}
 
 {% highlight C# %}

--- a/WindowsForms/TabControl/FAQ/How-to-programmatically-select-a-Tab.md
+++ b/WindowsForms/TabControl/FAQ/How-to-programmatically-select-a-Tab.md
@@ -16,7 +16,7 @@ To programmatically select a specific tab in the `TabControlAdv`, you can use th
 
 {% tabs %}
 
-{% highlight csharp %}
+{% highlight C# %}
 
 using System;
 using System.Windows.Forms;
@@ -62,7 +62,7 @@ namespace TabControlAdvExample
 }
 {% endhighlight %}
 
-{% highlight vbnet %}
+{% highlight VB %}
 
 Imports System
 Imports System.Windows.Forms


### PR DESCRIPTION
Hi Team,

Updated the "How to programmatically select a tab?" FAQ in the TabControlAdv WinForms documentation to:

Clarify that tabControlAdv1 refers to an instance of Syncfusion.Windows.Forms.Tools.TabControlAdv.

Avoid confusion with other tab controls like SfTab, which do not support SelectedIndex.

Provide both C# and VB.NET code examples in proper context.

Regards,
Harinath N