### PR TITLE
SEO-206704-Image-Alt-Missing-WindowsForms-Hotfix

### DIFF
--- a/WindowsForms/colorui/faq/How-to-add-a-ColorUI-Control-to-a-Popup-Menu.md
+++ b/WindowsForms/colorui/faq/How-to-add-a-ColorUI-Control-to-a-Popup-Menu.md
@@ -13,11 +13,11 @@ To add ColorUIControl to a PopupMenu, we need to use PopupMenu, PopupControlCont
 1. Drag and drop a ColorUIControl, a PopupMenu control, a PopupControlContainer control, a label control and a Panel control onto the form. Place the ColorUIControl inside the PopupControlContainer and the label inside the panel control.
 2. Right click PopupMenu and select 'Add Default ParentBarItem" from the verbs. 
 
-   ![](FAQ_images/Overview_img240.jpeg) 
+   ![add default parent bar item in colorui.](FAQ_images/Overview_img240.jpeg) 
 
 3. In the property grid of PopupMenu, expand ParentBarItem, then add a DropDownBarItem to the ParentBarItem using BarItem Collection Editor. Also set the PopupControlContainer as the DropDownBarItem's PopupControlContainer as shown in the image below.
 
-   ![](FAQ_images/Overview_img241.jpeg) 
+   ![the drop down bar item’s popup control container in colorui](FAQ_images/Overview_img241.jpeg) 
 
 4. In the MouseUp event of the Panel control call the PopupMenu.Show method.
 
@@ -43,6 +43,6 @@ End Sub
 {% endcapture %}
 {{ codesnippet1 | OrderList_Indent_Level_1 }}
 
-   ![](FAQ_images/Overview_img242.jpeg) 
+   ![the panel control call the popup menu.show method in colorui.](FAQ_images/Overview_img242.jpeg) 
 
 N> You can close the popup whenever a color is selected at run time. This is done using ColorUIControl.ColorSelected Event.


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Image Alt Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/206704/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B425BC1DA-899F-43C9-83EC-59BDC2E6D2D3%7D&file=Bing%20Issues%20-%20SEO.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Update the img alt tag|The image alt tag is important for SEO, so I updated it.|





Regards, 
Asha